### PR TITLE
add extra path to postfix master 

### DIFF
--- a/postfix3/service/postfix/run
+++ b/postfix3/service/postfix/run
@@ -29,6 +29,10 @@ if [[ -f "/usr/libexec/postfix/master" ]]; then
   cmd="/usr/libexec/postfix/master"
 fi
 
+if [[ -f "/usr/lib/postfix/sbin/master" ]]; then
+  cmd="/usr/lib/postfix/sbin/master"
+fi
+
 if [[ -f "/usr/lib/postfix/master" ]]; then
   cmd="/usr/lib/postfix/master"
 fi


### PR DESCRIPTION
Provided paths weren't working for me. This seems to be the latest path in a newly created image.